### PR TITLE
Multi-value counter support plus bug fixes.

### DIFF
--- a/collector/mangle.go
+++ b/collector/mangle.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func manglePerflibName(s string) (string) {
+func manglePerflibName(s string) string {
 	s = strings.ToLower(s)
 	s = strings.Replace(s, " ", "_", -1)
 	s = strings.Replace(s, ".", "", -1)
@@ -16,11 +16,12 @@ func manglePerflibName(s string) (string) {
 	s = strings.Replace(s, ")", "", -1)
 	s = strings.Replace(s, "+", "", -1)
 	s = strings.Replace(s, "-", "", -1)
+	s = strings.Replace(s, ",", "", -1)
 
 	return s
 }
 
-func manglePerflibCounterName(s string) (string) {
+func manglePerflibCounterName(s string) string {
 	s = manglePerflibName(s)
 
 	s = strings.Replace(s, "total_", "", -1)
@@ -43,8 +44,12 @@ func manglePerflibCounterName(s string) (string) {
 func MakePrometheusLabel(def *perflib.PerfCounterDef) (s string) {
 	s = manglePerflibCounterName(def.Name)
 
-	if def.IsCounter {
-		s += "_total"
+	if len(s) > 0 {
+		if IsCounter(def.CounterType) {
+			s += "_total"
+		} else if IsBaseValue(def.CounterType) && !strings.HasSuffix(s, "_base") {
+			s += "_max"
+		}
 	}
 
 	return
@@ -54,13 +59,13 @@ func pdhNameFromCounterDef(obj perflib.PerfObject, def perflib.PerfCounterDef) s
 	return fmt.Sprintf(`\%s(*)\%s`, obj.Name, def.Name)
 }
 
-func descFromCounterDef(obj perflib.PerfObject, def perflib.PerfCounterDef) (string, *prometheus.Desc) {
+func descFromCounterDef(obj perflib.PerfObject, def perflib.PerfCounterDef) *prometheus.Desc {
 	subsystem := manglePerflibName(obj.Name)
 	counterName := MakePrometheusLabel(&def)
 
 	labels := []string{"name"}
 
-	if def.Name == "" {
+	if len(obj.Instances) == 1 {
 		labels = []string{}
 	}
 
@@ -68,13 +73,14 @@ func descFromCounterDef(obj perflib.PerfObject, def perflib.PerfCounterDef) (str
 		labels = append(labels, PromotedLabelsForObject(obj.NameIndex)...)
 	}
 
-	if HasMergedLabels(obj.NameIndex) {
-		s, labelsForObject := MergedLabelsForInstance(obj.NameIndex, def.NameIndex)
-		counterName = s
-		labels = append(labels, labelsForObject)
-	}
+	// TODO - Label merging needs to be fixed for [230] Process
+	//if HasMergedLabels(obj.NameIndex) {
+	//	s, labelsForObject := MergedLabelsForInstance(obj.NameIndex, def.NameIndex)
+	//	counterName = s
+	//	labels = append(labels, labelsForObject)
+	//}
 
-	return counterName, prometheus.NewDesc(
+	return prometheus.NewDesc(
 		prometheus.BuildFQName(Namespace, subsystem, counterName),
 		fmt.Sprintf("perflib metric: %s (see /dump for docs) [%d]",
 			pdhNameFromCounterDef(obj, def), def.NameIndex),

--- a/collector/mapper.go
+++ b/collector/mapper.go
@@ -1,0 +1,91 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	PERF_COUNTER_RAWCOUNT_HEX           = 0x00000000
+	PERF_COUNTER_LARGE_RAWCOUNT_HEX     = 0x00000100
+	PERF_COUNTER_TEXT                   = 0x00000b00
+	PERF_COUNTER_RAWCOUNT               = 0x00010000
+	PERF_COUNTER_LARGE_RAWCOUNT         = 0x00010100
+	PERF_DOUBLE_RAW                     = 0x00012000
+	PERF_COUNTER_DELTA                  = 0x00400400
+	PERF_COUNTER_LARGE_DELTA            = 0x00400500
+	PERF_SAMPLE_COUNTER                 = 0x00410400
+	PERF_COUNTER_QUEUELEN_TYPE          = 0x00450400
+	PERF_COUNTER_LARGE_QUEUELEN_TYPE    = 0x00450500
+	PERF_COUNTER_100NS_QUEUELEN_TYPE    = 0x00550500
+	PERF_COUNTER_OBJ_TIME_QUEUELEN_TYPE = 0x00650500
+	PERF_COUNTER_COUNTER                = 0x10410400
+	PERF_COUNTER_BULK_COUNT             = 0x10410500
+	PERF_RAW_FRACTION                   = 0x20020400
+	PERF_LARGE_RAW_FRACTION             = 0x20020500
+	PERF_COUNTER_TIMER                  = 0x20410500
+	PERF_PRECISION_SYSTEM_TIMER         = 0x20470500
+	PERF_100NSEC_TIMER                  = 0x20510500
+	PERF_PRECISION_100NS_TIMER          = 0x20570500
+	PERF_OBJ_TIME_TIMER                 = 0x20610500
+	PERF_PRECISION_OBJECT_TIMER         = 0x20670500
+	PERF_SAMPLE_FRACTION                = 0x20c20400
+	PERF_COUNTER_TIMER_INV              = 0x21410500
+	PERF_100NSEC_TIMER_INV              = 0x21510500
+	PERF_COUNTER_MULTI_TIMER            = 0x22410500
+	PERF_100NSEC_MULTI_TIMER            = 0x22510500
+	PERF_COUNTER_MULTI_TIMER_INV        = 0x23410500
+	PERF_100NSEC_MULTI_TIMER_INV        = 0x23510500
+	PERF_AVERAGE_TIMER                  = 0x30020400
+	PERF_ELAPSED_TIME                   = 0x30240500
+	PERF_COUNTER_NODATA                 = 0x40000200
+	PERF_AVERAGE_BULK                   = 0x40020500
+	PERF_SAMPLE_BASE                    = 0x40030401
+	PERF_AVERAGE_BASE                   = 0x40030402
+	PERF_RAW_BASE                       = 0x40030403
+	PERF_PRECISION_TIMESTAMP            = 0x40030500
+	PERF_LARGE_RAW_BASE                 = 0x40030503
+	PERF_COUNTER_MULTI_BASE             = 0x42030500
+	PERF_COUNTER_HISTOGRAM_TYPE         = 0x80000000
+)
+
+var supportedCounterTypes = map[uint32]prometheus.ValueType{
+	PERF_COUNTER_RAWCOUNT_HEX:       prometheus.GaugeValue,
+	PERF_COUNTER_LARGE_RAWCOUNT_HEX: prometheus.GaugeValue,
+	PERF_COUNTER_RAWCOUNT:           prometheus.GaugeValue,
+	PERF_COUNTER_LARGE_RAWCOUNT:     prometheus.GaugeValue,
+	PERF_COUNTER_DELTA:              prometheus.CounterValue,
+	PERF_COUNTER_COUNTER:            prometheus.CounterValue,
+	PERF_COUNTER_BULK_COUNT:         prometheus.CounterValue,
+	PERF_RAW_FRACTION:               prometheus.GaugeValue,
+	PERF_LARGE_RAW_FRACTION:         prometheus.GaugeValue,
+	PERF_100NSEC_TIMER:              prometheus.CounterValue,
+	PERF_PRECISION_100NS_TIMER:      prometheus.CounterValue,
+	PERF_SAMPLE_FRACTION:            prometheus.GaugeValue,
+	PERF_100NSEC_TIMER_INV:          prometheus.CounterValue,
+	PERF_ELAPSED_TIME:               prometheus.GaugeValue,
+	PERF_SAMPLE_BASE:                prometheus.GaugeValue,
+	PERF_RAW_BASE:                   prometheus.GaugeValue,
+	PERF_LARGE_RAW_BASE:             prometheus.GaugeValue,
+}
+
+func IsCounter(counterType uint32) bool {
+	return supportedCounterTypes[counterType] == prometheus.CounterValue
+}
+
+func IsBaseValue(counterType uint32) bool {
+	return counterType == PERF_SAMPLE_BASE || counterType == PERF_RAW_BASE || counterType == PERF_LARGE_RAW_BASE
+}
+
+func IsElapsedTime(counterType uint32) bool {
+	return counterType == PERF_ELAPSED_TIME
+}
+
+func GetPrometheusValueType(counterType uint32) (prometheus.ValueType, error) {
+	val, ok := supportedCounterTypes[counterType]
+	if !ok {
+		return 0, fmt.Errorf("counter type %#08x is not supported", counterType)
+	}
+	return val, nil
+}

--- a/perflib/perflib.go
+++ b/perflib/perflib.go
@@ -136,6 +136,8 @@ type PerfObject struct {
 	Instances     []*PerfInstance
 	CounterDefs   []*PerfCounterDef
 
+	Frequency int64
+
 	rawData *perfObjectType
 }
 
@@ -168,7 +170,7 @@ type PerfCounterDef struct {
 	// PERF_TIMER_100NS
 	IsNanosecondCounter bool
 
-	rawData     *perfCounterDefinition
+	rawData *perfCounterDefinition
 }
 
 type PerfCounter struct {
@@ -317,6 +319,7 @@ func QueryPerformanceData(query string) ([]*PerfObject, error) {
 			HelpTextIndex: uint(obj.ObjectHelpTitleIndex),
 			Instances:     instances,
 			CounterDefs:   counterDefs,
+			Frequency:     obj.PerfFreq,
 			rawData:       obj,
 		}
 
@@ -333,8 +336,8 @@ func QueryPerformanceData(query string) ([]*PerfObject, error) {
 
 				CounterType: def.CounterType,
 
-				IsCounter:   def.CounterType&0x400 > 0,
-				IsBaseValue: def.CounterType&0x20000000 > 0,
+				IsCounter:           def.CounterType&0x400 > 0,
+				IsBaseValue:         def.CounterType&0x20000000 > 0,
 				IsNanosecondCounter: def.CounterType&0x00100000 > 0,
 			}
 		}


### PR DESCRIPTION
This PR adds support for multi-value counter.  `_max` is being appended to metrics that are derived from base counter types (making them unique).  Counter types are also being explicitly mapped to prometheus metric types.  Finally, limiting which counter types are being exposed as metrics (e.g. it doesn't make sense to expose counter types like `PERF_AVERAGE_BULK` ).  This addresses issues #1, #10.

This PR also fixes the following bug:
- `perflib_system_system_up_time` converted to UNIX time (fixes #6)
- Single instance counters should not have labels
- Remove commas when mangling metric names 
- Remove `Total` instances

Unfortunately, I had to comment out the label merging code because it causes a panic when the 230 (Process) object is enabled (see #7).

I'm currently running this across ~600 Windows nodes, a mix of Windows Server 2016 and 2019.