### PR TITLE
GitHub actions stub

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,20 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: windows-2016
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Build
+      run: go build -v .


### PR DESCRIPTION
To nobody's surprise, GitHub Actions is based on Azure, which means... native Windows support!

This adds a simple CI stub that builds the main perflib_exporter binary.