### PR TITLE
WIP: [BUGFIX] Add duplicate distinction to avoid duplicate metrics

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -76,7 +76,7 @@ func (c PerflibCollector) Collect(ch chan<- prometheus.Metric) (err error) {
 	for _, object := range objects {
 		n := object.NameIndex
 
-		for _, instance := range object.Instances {
+		for i, instance := range object.Instances {
 			name := instance.Name
 
 			// _Total metrics do not fit into the Prometheus model - we try to merge similar
@@ -128,6 +128,10 @@ func (c PerflibCollector) Collect(ch chan<- prometheus.Metric) (err error) {
 
 				if HasPromotedLabels(n) {
 					labels = append(labels, PromotedLabelValuesForInstance(n, instance)...)
+				}
+
+				if RequiresDuplicateDistinction(object) {
+					labels = append(labels, DuplicateDistinctionLabelValue(instance, i)...)
 				}
 
 				// TODO - Label merging needs to be fixed for [230] Process

--- a/collector/duplicate.go
+++ b/collector/duplicate.go
@@ -1,0 +1,42 @@
+package collector
+
+import (
+	"github.com/leoluk/perflib_exporter/perflib"
+	"strconv"
+)
+
+var duplicates = map[*perflib.PerfObject]bool{}
+
+// RequiresDuplicateDistinction determines whether the Perflib object contains instances with duplicate names.
+func RequiresDuplicateDistinction(object *perflib.PerfObject) bool {
+	return indexDuplicateDistinctionPool(object)
+}
+
+// DuplicateDistinctionLabel returns the labels to allow duplicate distinction.
+func DuplicateDistinctionLabel() []string {
+	return []string{"instance_unique_id", "instance_index"}
+}
+
+// DuplicateDistinctionLabelValue returns the label values to allow duplicate distinction.
+func DuplicateDistinctionLabelValue(instance *perflib.PerfInstance, index int) []string {
+	return []string{strconv.Itoa(int(instance.UniqueID())), strconv.Itoa(index)}
+}
+
+// indexDuplicateDistinctionPool indexes the Perflib object instances for duplicate distinction.
+func indexDuplicateDistinctionPool(object *perflib.PerfObject) bool {
+	if _, ok := duplicates[object]; !ok {
+		duplicates[object] = containsDuplicateNames(object.Instances)
+	}
+	return duplicates[object]
+}
+
+func containsDuplicateNames(instances []*perflib.PerfInstance) bool {
+	var names = map[string]struct{}{}
+	for _, instance := range instances {
+		if _, duplicate := names[instance.Name]; duplicate {
+			return true
+		}
+		names[instance.Name] = struct{}{}
+	}
+	return false
+}

--- a/collector/mangle.go
+++ b/collector/mangle.go
@@ -73,6 +73,10 @@ func descFromCounterDef(obj perflib.PerfObject, def perflib.PerfCounterDef) *pro
 		labels = append(labels, PromotedLabelsForObject(obj.NameIndex)...)
 	}
 
+	if RequiresDuplicateDistinction(&obj) {
+		labels = append(labels, DuplicateDistinctionLabel()...)
+	}
+
 	// TODO - Label merging needs to be fixed for [230] Process
 	//if HasMergedLabels(obj.NameIndex) {
 	//	s, labelsForObject := MergedLabelsForInstance(obj.NameIndex, def.NameIndex)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/leoluk/perflib_exporter
 
-go 1.14
-
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/prometheus/client_golang v0.9.2

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/leoluk/perflib_exporter
 
+go 1.14
+
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/prometheus/client_golang v0.9.2

--- a/perflib/perflib.go
+++ b/perflib/perflib.go
@@ -153,6 +153,10 @@ type PerfInstance struct {
 	rawCounterBlock *perfCounterBlock
 }
 
+func (p *PerfInstance) UniqueID() uint32 {
+	return p.rawData.UniqueID
+}
+
 type PerfCounterDef struct {
 	Name          string
 	NameIndex     uint


### PR DESCRIPTION
In case of duplicate instance names beneath an object, add two labels for distinction.