### PR TITLE
save memory by calling RegCloseKey

### DIFF
--- a/perflib/perflib.go
+++ b/perflib/perflib.go
@@ -216,6 +216,8 @@ func queryRawData(query string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode query string: %v", err)
 	}
 
+	defer syscall.RegCloseKey(syscall.HKEY_PERFORMANCE_DATA)
+
 	for {
 		bufLen := uint32(len(buffer))
 
@@ -231,6 +233,7 @@ func queryRawData(query string) ([]byte, error) {
 			newBuffer := make([]byte, len(buffer)+16384)
 			copy(newBuffer, buffer)
 			buffer = newBuffer
+			syscall.RegCloseKey(syscall.HKEY_PERFORMANCE_DATA)
 			continue
 		} else if err != nil {
 			if errno, ok := err.(syscall.Errno); ok {


### PR DESCRIPTION
this should save a leak in windows_exporter:

https://docs.microsoft.com/en-us/windows/win32/perfctrs/using-the-registry-functions-to-consume-counter-data

> Be sure to use the RegCloseKey function to close the handle to the key
> when you are finished obtaining the performance data. This is
> important for both the local and remote cases:

https://github.com/prometheus-community/windows_exporter/issues/813#issuecomment-883188834

Tests with this patch from @geraudster:

https://github.com/prometheus-community/windows_exporter/issues/813#issuecomment-973047126