### PR TITLE
Remove the reg key close on hdata performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tools/dumps
 *.exe
 _*.go
 *~
+vendor/

--- a/perflib/perflib.go
+++ b/perflib/perflib.go
@@ -1,111 +1,112 @@
 /*
-Go bindings for the HKEY_PERFORMANCE_DATA perflib / Performance Counters interface.
+	Go bindings for the HKEY_PERFORMANCE_DATA perflib / Performance Counters interface.
 
-# Overview
+	Overview
 
-HKEY_PERFORMANCE_DATA is a low-level alternative to the higher-level PDH library and WMI.
-It operates on blocks of counters and only returns raw values without calculating rates
-or formatting them, which is exactly what you want for, say, a Prometheus exporter
-(not so much for a GUI like Windows Performance Monitor).
+	HKEY_PERFORMANCE_DATA is a low-level alternative to the higher-level PDH library and WMI.
+	It operates on blocks of counters and only returns raw values without calculating rates
+	or formatting them, which is exactly what you want for, say, a Prometheus exporter
+	(not so much for a GUI like Windows Performance Monitor).
 
-Its overhead is much lower than the high-level libraries.
+	Its overhead is much lower than the high-level libraries.
 
-It operates on the same set of perflib providers as PDH and WMI. See this document
-for more details on the relationship between the different libraries:
-https://msdn.microsoft.com/en-us/library/windows/desktop/aa371643(v=vs.85).aspx
+	It operates on the same set of perflib providers as PDH and WMI. See this document
+	for more details on the relationship between the different libraries:
+	https://msdn.microsoft.com/en-us/library/windows/desktop/aa371643(v=vs.85).aspx
 
-Example C++ source code:
-https://msdn.microsoft.com/de-de/library/windows/desktop/aa372138(v=vs.85).aspx
+	Example C++ source code:
+	https://msdn.microsoft.com/de-de/library/windows/desktop/aa372138(v=vs.85).aspx
 
-For now, the API is not stable and is probably going to change in future
-perflib_exporter releases. If you want to use this library, send the author an email
-so we can discuss your requirements and stabilize the API.
+	For now, the API is not stable and is probably going to change in future
+	perflib_exporter releases. If you want to use this library, send the author an email
+	so we can discuss your requirements and stabilize the API.
 
-# Names
+	Names
 
-Counter names and help texts are resolved by looking up an index in a name table.
-Since Microsoft loves internalization, both names and help texts can be requested
-any locally available language.
+	Counter names and help texts are resolved by looking up an index in a name table.
+	Since Microsoft loves internalization, both names and help texts can be requested
+	any locally available language.
 
-The library automatically loads the name tables and resolves all identifiers
-in English ("Name" and "HelpText" struct members). You can manually resolve
-identifiers in a different language by using the NameTable API.
+	The library automatically loads the name tables and resolves all identifiers
+	in English ("Name" and "HelpText" struct members). You can manually resolve
+	identifiers in a different language by using the NameTable API.
 
-# Performance Counters intro
+	Performance Counters intro
 
-Windows has a system-wide performance counter mechanism. Most performance counters
-are stored as actual counters, not gauges (with some exceptions).
-There's additional metadata which defines how the counter should be presented to the user
-(for example, as a calculated rate). This library disregards all of the display metadata.
+	Windows has a system-wide performance counter mechanism. Most performance counters
+	are stored as actual counters, not gauges (with some exceptions).
+	There's additional metadata which defines how the counter should be presented to the user
+	(for example, as a calculated rate). This library disregards all of the display metadata.
 
-At the top level, there's a number of performance counter objects.
-Each object has counter definitions, which contain the metadata for a particular
-counter, and either zero or multiple instances. We hide the fact that there are
-objects with no instances, and simply return a single null instance.
+	At the top level, there's a number of performance counter objects.
+	Each object has counter definitions, which contain the metadata for a particular
+	counter, and either zero or multiple instances. We hide the fact that there are
+	objects with no instances, and simply return a single null instance.
 
-There's one counter per counter definition and instance (or the object itself, if
-there are no instances).
+	There's one counter per counter definition and instance (or the object itself, if
+	there are no instances).
 
-Behind the scenes, every perflib DLL provides one or more objects.
-Perflib has a registry where DLLs are dynamically registered and
-unregistered. Some third party applications like VMWare provide their own counters,
-but this is, sadly, a rare occurrence.
+	Behind the scenes, every perflib DLL provides one or more objects.
+	Perflib has a registry where DLLs are dynamically registered and
+	unregistered. Some third party applications like VMWare provide their own counters,
+	but this is, sadly, a rare occurrence.
 
-Different Windows releases have different numbers of counters.
+	Different Windows releases have different numbers of counters.
 
-Objects and counters are identified by well-known indices.
+	Objects and counters are identified by well-known indices.
 
-Here's an example object with one instance:
+	Here's an example object with one instance:
 
-	4320 WSMan Quota Statistics [7 counters, 1 instance(s)]
-	`-- "WinRMService"
-		`-- Total Requests/Second [4322] = 59
-		`-- User Quota Violations/Second [4324] = 0
-		`-- System Quota Violations/Second [4326] = 0
-		`-- Active Shells [4328] = 0
-		`-- Active Operations [4330] = 0
-		`-- Active Users [4332] = 0
-		`-- Process ID [4334] = 928
+		4320 WSMan Quota Statistics [7 counters, 1 instance(s)]
+		`-- "WinRMService"
+			`-- Total Requests/Second [4322] = 59
+			`-- User Quota Violations/Second [4324] = 0
+			`-- System Quota Violations/Second [4326] = 0
+			`-- Active Shells [4328] = 0
+			`-- Active Operations [4330] = 0
+			`-- Active Users [4332] = 0
+			`-- Process ID [4334] = 928
 
-All "per second" metrics are counters, the rest are gauges.
+	All "per second" metrics are counters, the rest are gauges.
 
-Another example, with no instance:
+	Another example, with no instance:
 
-	4600 Network QoS Policy [6 counters, 1 instance(s)]
-	`-- (default)
-		`-- Packets transmitted [4602] = 1744
-		`-- Packets transmitted/sec [4604] = 4852
-		`-- Bytes transmitted [4606] = 4853
-		`-- Bytes transmitted/sec [4608] = 180388626632
-		`-- Packets dropped [4610] = 0
-		`-- Packets dropped/sec [4612] = 0
+		4600 Network QoS Policy [6 counters, 1 instance(s)]
+		`-- (default)
+			`-- Packets transmitted [4602] = 1744
+			`-- Packets transmitted/sec [4604] = 4852
+			`-- Bytes transmitted [4606] = 4853
+			`-- Bytes transmitted/sec [4608] = 180388626632
+			`-- Packets dropped [4610] = 0
+			`-- Packets dropped/sec [4612] = 0
 
-You can access the same values using PowerShell's Get-Counter cmdlet
-or the Performance Monitor.
+	You can access the same values using PowerShell's Get-Counter cmdlet
+	or the Performance Monitor.
 
-	> Get-Counter '\WSMan Quota Statistics(WinRMService)\Process ID'
+		> Get-Counter '\WSMan Quota Statistics(WinRMService)\Process ID'
 
-	Timestamp                 CounterSamples
-	---------                 --------------
-	1/28/2018 10:18:00 PM     \\DEV\wsman quota statistics(winrmservice)\process id :
-							  928
+		Timestamp                 CounterSamples
+		---------                 --------------
+		1/28/2018 10:18:00 PM     \\DEV\wsman quota statistics(winrmservice)\process id :
+								  928
 
-	>  (Get-Counter '\Process(Idle)\% Processor Time').CounterSamples[0] | Format-List *
-	[..detailed output...]
+		>  (Get-Counter '\Process(Idle)\% Processor Time').CounterSamples[0] | Format-List *
+		[..detailed output...]
 
-Data for some of the objects is also available through WMI:
+	Data for some of the objects is also available through WMI:
 
-	> Get-CimInstance Win32_PerfRawData_Counters_WSManQuotaStatistics
+		> Get-CimInstance Win32_PerfRawData_Counters_WSManQuotaStatistics
 
-	Name                           : WinRMService
-	[...]
-	ActiveOperations               : 0
-	ActiveShells                   : 0
-	ActiveUsers                    : 0
-	ProcessID                      : 928
-	SystemQuotaViolationsPerSecond : 0
-	TotalRequestsPerSecond         : 59
-	UserQuotaViolationsPerSecond   : 0
+		Name                           : WinRMService
+		[...]
+		ActiveOperations               : 0
+		ActiveShells                   : 0
+		ActiveUsers                    : 0
+		ProcessID                      : 928
+		SystemQuotaViolationsPerSecond : 0
+		TotalRequestsPerSecond         : 59
+		UserQuotaViolationsPerSecond   : 0
+
 */
 package perflib
 


### PR DESCRIPTION
If you check the error from RegCloseKey it returns an invalid handle, and for whatever reason will crash the debugger if using delve.