### PR TITLE
remove reg close

### DIFF
--- a/perflib/perflib.go
+++ b/perflib/perflib.go
@@ -220,8 +220,6 @@ func queryRawData(query string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to encode query string: %v", err)
 	}
 
-	defer syscall.RegCloseKey(syscall.HKEY_PERFORMANCE_DATA)
-
 	for {
 		bufLen := uint32(len(buffer))
 
@@ -237,7 +235,6 @@ func queryRawData(query string) ([]byte, error) {
 			newBuffer := make([]byte, len(buffer)+16384)
 			copy(newBuffer, buffer)
 			buffer = newBuffer
-			syscall.RegCloseKey(syscall.HKEY_PERFORMANCE_DATA)
 			continue
 		} else if err != nil {
 			if errno, ok := err.(syscall.Errno); ok {


### PR DESCRIPTION
If you check the error from RegCloseKey it returns an invalid handle, and for whatever reason will crash the debugger if using delve.
