### PR TITLE
Expose nametables

### DIFF
--- a/perflib/nametable.go
+++ b/perflib/nametable.go
@@ -12,11 +12,11 @@ type nameTableLookuper interface {
 }
 
 func (p *perfObjectType) LookupName() string {
-	return counterNameTable.LookupString(p.ObjectNameTitleIndex)
+	return CounterNameTable.LookupString(p.ObjectNameTitleIndex)
 }
 
 func (p *perfObjectType) LookupHelp() string {
-	return helpNameTable.LookupString(p.ObjectHelpTitleIndex)
+	return HelpNameTable.LookupString(p.ObjectHelpTitleIndex)
 }
 
 type NameTable struct {

--- a/perflib/perflib.go
+++ b/perflib/perflib.go
@@ -124,8 +124,8 @@ import (
 // TODO: There's a LittleEndian field in the PERF header - we ought to check it
 var bo = binary.LittleEndian
 
-var counterNameTable NameTable
-var helpNameTable NameTable
+var CounterNameTable NameTable
+var HelpNameTable NameTable
 
 const averageCount64Type = 1073874176
 
@@ -270,8 +270,8 @@ func init() {
 	// Not sure if we should resolve the names at all or just have the caller do it on demand
 	// (for many use cases the index is sufficient)
 
-	counterNameTable = *QueryNameTable("Counter 009")
-	helpNameTable = *QueryNameTable("Help 009")
+	CounterNameTable = *QueryNameTable("Counter 009")
+	HelpNameTable = *QueryNameTable("Help 009")
 }
 
 /*

--- a/perflib/raw_types.go
+++ b/perflib/raw_types.go
@@ -130,11 +130,11 @@ func (p *perfCounterDefinition) BinaryReadFrom(r io.Reader) error {
 }
 
 func (p *perfCounterDefinition) LookupName() string {
-	return counterNameTable.LookupString(p.CounterNameTitleIndex)
+	return CounterNameTable.LookupString(p.CounterNameTitleIndex)
 }
 
 func (p *perfCounterDefinition) LookupHelp() string {
-	return helpNameTable.LookupString(p.CounterHelpTitleIndex)
+	return HelpNameTable.LookupString(p.CounterHelpTitleIndex)
 }
 
 /*


### PR DESCRIPTION
This PR allow external programs to re-use the internal NameTables which is loaded from the init function.

At the moment, external programs may has to [call](https://github.com/prometheus-community/windows_exporter/blob/79781c6d75fc5cef4d28685b17a4b581e038aa10/collector/perflib.go#L14) `QueryNameTable("Counter 009")`, which results into loading the name tables twice.